### PR TITLE
Add healthcheck endpoint and index page

### DIFF
--- a/_healthcheck/index.html
+++ b/_healthcheck/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>OK</title>
+  <meta name="robots" content="noindex">
+</head>
+<body>OK</body>
+</html>

--- a/project/platform/web.locations.yaml
+++ b/project/platform/web.locations.yaml
@@ -90,3 +90,11 @@
 "/signature-assets":
   root: 'signature/dist/signature-assets'
   allow: true
+
+"/_healthcheck":
+  root: '_healthcheck'
+  allow: true
+  scripts: false
+  expires: -1
+  index:
+    - index.html


### PR DESCRIPTION
Add a simple static healthcheck page at _healthcheck/index.html returning "OK" and register a "/_healthcheck" location in project/platform/web.locations.yaml. The location serves from the _healthcheck directory, disables scripts, sets expires to -1 (no caching), and uses index.html — intended for load balancer or monitoring health checks.